### PR TITLE
makepkg: avoid pwd -P

### DIFF
--- a/scripts/libmakepkg/util/util.sh.in
+++ b/scripts/libmakepkg/util/util.sh.in
@@ -60,7 +60,7 @@ canonicalize_path() {
 	if [[ -d $path ]]; then
 		(
 			cd_safe "$path"
-			pwd -P
+			pwd
 		)
 	else
 		printf "%s\n" "$path"

--- a/scripts/makepkg.sh.in
+++ b/scripts/makepkg.sh.in
@@ -43,7 +43,7 @@ unset GREP_OPTIONS
 declare -r makepkg_version='@PACKAGE_VERSION@'
 declare -r confdir='@sysconfdir@'
 declare -r BUILDSCRIPT='@BUILDSCRIPT@'
-declare -r startdir="$(pwd -P)"
+declare -r startdir="$(pwd)"
 
 LIBRARY=${LIBRARY:-'@libmakepkgdir@'}
 


### PR DESCRIPTION
Due to a Cygwin change, virtual drives are now treated as symlinks, and
pwd -P dutifully dereferences these even with my patches to Cygwin to
avoid implicitly dereferencing them when starting native processes.

For msys2/msys2-runtime#41