### PR TITLE
pacman.c: handle cr on stdin as well

### DIFF
--- a/src/pacman/pacman.c
+++ b/src/pacman/pacman.c
@@ -1156,6 +1156,12 @@ int main(int argc, char *argv[])
 				if(line[nread - 1] == '\n') {
 					/* remove trailing newline */
 					line[nread - 1] = '\0';
+#ifdef __MSYS__
+					if (line[nread - 2] == '\r') {
+						/* remove trailing carriage returns */
+						line[nread - 2] = '\0';
+					}
+#endif
 				}
 				if(line[0] == '\0') {
 					/* skip empty lines */


### PR DESCRIPTION
Improves compatibility with Windows targets, specifically when using
powershell for string transforming package names and piping into
pacman as it's virtually impossible to send newline only terminated
strings through pipes

Allows for stuff such as

```powershell
$a="vim nano"
$b="cmake ninja"
$a.Split(' '), $b.Split(' ').ForEach({Write-Output mingw-w64-ucrt-x86_64-$_}) |
  pacman -S --needed -
```

Signed-off-by: Christopher Degawa <ccom@randomderp.com>