### PR TITLE
Fix building staticlibs with LTO

### DIFF
--- a/scripts/libmakepkg/buildenv/lto.sh.in
+++ b/scripts/libmakepkg/buildenv/lto.sh.in
@@ -33,5 +33,10 @@ buildenv_lto() {
 	if check_option "lto" "y"; then
 		CFLAGS+=" -flto"
 		CXXFLAGS+=" -flto"
+		LDFLAGS+=" -flto"
+		if check_option "staticlibs" "y"; then
+			CFLAGS+=" -ffat-lto-objects"
+			CXXFLAGS+=" -ffat-lto-objects"
+		fi
 	fi
 }


### PR DESCRIPTION
Unless `-ffat-lto-objects` get passed to the compiler, It only generates LTO bytecode.

see:
https://wiki.ubuntu.com/ToolChain/LTO : Implementation
https://fedoraproject.org/wiki/Changes/LTOBuildImprovements
https://en.opensuse.org/openSUSE:LTO