### PR TITLE
Make lint_pkgbuild opt-in via MAKEPKG_LINT_PKGBUILD=1

### DIFF
--- a/scripts/makepkg.sh.in
+++ b/scripts/makepkg.sh.in
@@ -1207,8 +1207,11 @@ fi
 
 pkgbase=${pkgbase:-${pkgname[0]}}
 
-# check the PKGBUILD for some basic requirements
-lint_pkgbuild || exit $E_PKGBUILD_ERROR
+# MSYS2: lint_pkgbuild is very slow with cygwin bash, so make it opt-in
+if (( MAKEPKG_LINT_PKGBUILD )); then
+	# check the PKGBUILD for some basic requirements
+	lint_pkgbuild || exit $E_PKGBUILD_ERROR
+fi
 
 if (( !SOURCEONLY && !PRINTSRCINFO )); then
 	merge_arch_attrs


### PR DESCRIPTION
Cygwin bash is struggling with the thousands of commands that get invoked when lint_pkgbuild is run. This especially is annoying for split packages because the calls get multiplied by the package count.

For example when running --printsrcinfo:

msys/brotli (4 packages)
* 39.8 seconds with linting
* 7 seconds without

msys/tar (1 package)
* 10.2 seconds with linting
* 2 seconds without

This changes the default to not lint the PKGBUILD and adds a MAKEPKG_LINT_PKGBUILD env var that can be used to enable linting. We can for example enable this in CI.