### PR TITLE
libpacman: Do strip all symbols from EXEs and DLLs

### DIFF
--- a/scripts/libmakepkg/tidy/strip.sh.in
+++ b/scripts/libmakepkg/tidy/strip.sh.in
@@ -202,7 +202,7 @@ tidy_strip() {
 
 			case "$(@FILECMD@ -bi "$binary")" in
 				*application/x-dosexec*) # Windows executables and dlls
-					strip_flags="$STRIP_SHARED";;
+					strip_flags="$STRIP_BINARIES";;
 				*application/x-archive*) # Static and Import Libraries (*.a and *.dll.a)
 					strip_flags="$STRIP_STATIC"
 					STRIPLTO=1;;


### PR DESCRIPTION
This matches the case for 'EXEC (Executable file)' below.

Passing `--strip-all` instead of `--strip-unneeded` to `strip` can make installed executables a bit smaller. For example, stripping all symbols from `/mingw64/bin/gcc.exe` can reduce its size from 2,351,500 to 2,344,448 (-7,052).

Microsoft documentation also suggests that there should be no symbol in PE files; see references about `PointerToSymbolTable` and `NumberOfSymbols`.

Reference: https://learn.microsoft.com/en-us/windows/win32/debug/pe-format
Signed-off-by: LIU Hao <lh_mouse@126.com>