### PR TITLE
[BACKPORT] libmakepkg: fix compatibility with bash-5.2 globskipdots

### DIFF
--- a/scripts/libmakepkg/lint_package/dotfiles.sh.in
+++ b/scripts/libmakepkg/lint_package/dotfiles.sh.in
@@ -29,10 +29,17 @@ lint_package_functions+=('check_dotfiles')
 
 check_dotfiles() {
 	local ret=0
+
+	local shellopts=$(shopt -p nullglob)
+	shopt -s nullglob
+
 	for f in "$pkgdir"/.*; do
 		[[ ${f##*/} == . || ${f##*/} == .. ]] && continue
 		error "$(gettext "Dotfile found in package root '%s'")" "$f"
 		ret=1
 	done
+
+	eval "$shellopts"
+
 	return $ret
 }


### PR DESCRIPTION
Bash 5.2 has a new globskipdots option, which is enabled by default. The check_dotfiles lint fails with globskipdots due to the assumption that at least the "." and ".." paths will match. Disabling globskipdots would be the usual solution, but that fails on bash<5.2.  Instead, enable nullglob for this check.

Signed-off-by: Allan McRae <allan@archlinux.org>