### PR TITLE
libmakepkg: fix compatibility with bash-5.2 patsub_replacement

### DIFF
--- a/scripts/libmakepkg/source/file.sh.in
+++ b/scripts/libmakepkg/source/file.sh.in
@@ -60,11 +60,11 @@ download_file() {
 	# replace %o by the temporary dlfile if it exists
 	if [[ ${cmdline[*]} = *%o* ]]; then
 		dlfile=$filename.part
-		cmdline=("${cmdline[@]//%o/$dlfile}")
+		cmdline=("${cmdline[@]//%o/"$dlfile"}")
 	fi
 	# add the URL, either in place of %u or at the end
 	if [[ ${cmdline[*]} = *%u* ]]; then
-		cmdline=("${cmdline[@]//%u/$url}")
+		cmdline=("${cmdline[@]//%u/"$url"}")
 	else
 		cmdline+=("$url")
 	fi


### PR DESCRIPTION
Bash-5.2 introduced the patsub_replacement shell option, which is enabled by default.  Apparently is it supposed to handle a sed-like idiom, but what it does achieve is making any substitution involving a "&" requiring special care.

For makepkg's DLAGENTS, we replace "%o" and "%u" if present.  Any "&" in the replacement fields triggers patsub_replacement unless quoted.  This is particularly important for the URL field.

Add relevant quotes to avoid issues.