### PR TITLE
makepkg.sh.in: allow split packages for MINGW packages

### DIFF
--- a/scripts/makepkg.sh.in
+++ b/scripts/makepkg.sh.in
@@ -444,7 +444,7 @@ run_check() {
 }
 
 run_package() {
-	run_function_safe "package${1:+_$1}"
+	run_function_safe "package${1:+_${1#${MINGW_PACKAGE_PREFIX}-}}"
 }
 
 find_libdepends() {


### PR DESCRIPTION
@lazka 

I did not look around of how to call the scripts to automagically move this change into the `pacman` package.  Could you please point me where to start or could you propagate to `pacman`'s `PKGBUILD` and Co.?

The script below run from the top directory of `MINGW-packages` removes the then obsolete wrappers (dynamically generating `PKGBUILD` functions prefixed with `${MINGW_PACKAGE_PREFIX}-`).  See comment in code for option to not increase `PKGREL`.

```bash
#! /usr/bin/bash

while IFS= read -r p; do
awk '
  { gsub(/\s+$/,""); }
  # comment out next line if PKGREL should NOT be increased by 1.
  /^pkgrel=[0-9]+$/ { gsub(/^pkgrel=/,""); print "pkgrel=" ($0+1); next; }
  /template start; name=mingw-w64-splitpkg-wrappers;/ { exit; }
  /^\s*$/{ nls++; next; }
  { if(nls){for(i=1;i<=nls;i++)print "";nls=0;} print; }' "$p" > "$p.tmp" && mv "$p.tmp" "$p"
done < <(grep -l 'mingw-w64-splitpkg-wrappers;' */PKGBUILD)
```

Off-topic: Interested in generating debug packages with `makepkg`?  If yes I could then try to get something up and running, for `GCC` in the first place at least. Later for `CLANG` ... hopefully.