### PR TITLE
Revert "makepkg: bash v4 compat"

### DIFF
--- a/scripts/makepkg.sh.in
+++ b/scripts/makepkg.sh.in
@@ -424,7 +424,7 @@ run_function() {
 
 		$pkgfunc &>"$logpipe"
 
-		wait $teepid
+		wait -f $teepid
 		rm "$logpipe"
 	else
 		"$pkgfunc"


### PR DESCRIPTION
This reverts commit 1fbb46db545fad72daab79d769f19a4ae4cea6e3.

We are on bash v5 for a long time now

See #29