### PR TITLE
Disable CheckSpace in default config

### DIFF
--- a/etc/pacman.conf.in
+++ b/etc/pacman.conf.in
@@ -32,7 +32,7 @@ Architecture = auto
 #UseSyslog
 #Color
 #NoProgressBar
-CheckSpace
+#CheckSpace
 #VerbosePkgLists
 ParallelDownloads = 5
 


### PR DESCRIPTION
Disable CheckSpace in the default pacman.conf because on many MSYS2 installations the free space checking is excruciatingly slow.

The extra safety afforded by this feature is not justified by the very painful experience of many users, and the situation of not having sufficient free space for packages is very unlikely on modern hardware.