### PR TITLE
fixup! Core update

### DIFF
--- a/src/pacman/sync.c
+++ b/src/pacman/sync.c
@@ -856,11 +856,19 @@ static int sync_trans(alpm_list_t *targets)
 
 	if(config->op_s_upgrade) {
 #ifdef __MSYS__
-		if((retval = core_update(&found_core_updates))) {
-			return retval;
-		}
-		if(found_core_updates) {
-			return retval;
+		if (config->print || config->op_s_downloadonly || strcmp(config->rootdir, "/") != 0) {
+			if(alpm_sync_sysupgrade_core(config->handle, config->op_s_upgrade >= 2) == -1) {
+				pm_printf(ALPM_LOG_ERROR, "%s\n", alpm_strerror(alpm_errno(config->handle)));
+				trans_release();
+				return 1;
+			}
+		} else {
+			if((retval = core_update(&found_core_updates))) {
+				return retval;
+			}
+			if(found_core_updates) {
+				return retval;
+			}
 		}
 #endif
 		if(!config->print) {


### PR DESCRIPTION
don't terminate all processes and exit during core updates if:
* asked to print packages only
* asked to download packages only
* asked to operate against a different root

Fixes msys2/MSYS2-packages#2301