### PR TITLE
Purge *.orig files by default

### DIFF
--- a/etc/makepkg.conf.in
+++ b/etc/makepkg.conf.in
@@ -105,7 +105,7 @@ MAN_DIRS=({usr{,/local}{,/share},opt/*}/{man,info})
 #-- Doc directories to remove (if !docs is specified)
 DOC_DIRS=(usr/{,local/}{,share/}{doc,gtk-doc} opt/*/{doc,gtk-doc})
 #-- Files to be removed from all packages (if purge is specified)
-PURGE_TARGETS=(usr/{,share}/info/dir .packlist *.pod)
+PURGE_TARGETS=(usr/{,share}/info/dir .packlist *.pod *.orig)
 #-- Directory to store source code in for debug packages
 DBGSRCDIR="/usr/src/debug"
 #-- Prefix and directories for library autodeps


### PR DESCRIPTION
This avoids *.orig files generated by patch to be installed.